### PR TITLE
fix: update get_multiple_places_images function to resolver world place IDs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,8 @@ jobs:
           image-tag: "latest"
           install-awslocal: "true"
           configuration: DEBUG=1,SERVICES=sns,s3,sqs
+        env:
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 
       - name: Setup AWS resources in LocalStack
         run: |

--- a/src/api/get.rs
+++ b/src/api/get.rs
@@ -347,10 +347,10 @@ pub struct GetMultiplePlacesImagesResponse {
     pub place_data: PlaceDataResponse,
 }
 
-#[tracing::instrument(skip(database))]
+#[tracing::instrument(skip(database, places_client))]
 #[utoipa::path(
     tag = "images",
-    context_path = "/api", 
+    context_path = "/api",
     params(
         GetMultiplePlacesImagesQuery
     ),
@@ -358,6 +358,7 @@ pub struct GetMultiplePlacesImagesResponse {
     responses(
         (status = 200, description = "List images for multiple places", body = GetMultiplePlacesImagesResponse),
         (status = 400, description = "Invalid place IDs format"),
+        (status = 502, description = "Failed to resolve world name"),
     )
 )]
 #[post("/places/images")]
@@ -365,6 +366,7 @@ async fn get_multiple_places_images(
     query_params: Query<GetMultiplePlacesImagesQuery>,
     request: Json<GetMultiplePlacesImagesBody>,
     database: Data<Database>,
+    places_client: Data<PlacesClient>,
 ) -> impl Responder {
     let GetMultiplePlacesImagesQuery { offset, limit } = query_params.into_inner();
     let GetMultiplePlacesImagesBody { places_ids } = request.into_inner();
@@ -373,12 +375,36 @@ async fn get_multiple_places_images(
         return HttpResponse::BadRequest().json(ResponseError::new("no place IDs provided"));
     }
 
-    let Ok(images_count) = database.get_multiple_places_images_count(&places_ids).await else {
+    let mut resolved_ids: Vec<String> = Vec::new();
+    for id in places_ids {
+        if id.ends_with(".eth") {
+            match places_client.get_world_place_ids(&id).await {
+                Ok(ids) => resolved_ids.extend(ids),
+                Err(e) => {
+                    tracing::error!("Failed to resolve world name '{}': {}", id, e);
+                    return HttpResponse::BadGateway()
+                        .json(ResponseError::new(&format!("failed to resolve world name: {e}")));
+                }
+            }
+        } else {
+            resolved_ids.push(id);
+        }
+    }
+
+    if resolved_ids.is_empty() {
+        let place_data = PlaceDataResponse { max_images: 0 };
+        return HttpResponse::Ok().json(GetMultiplePlacesImagesResponse {
+            images: vec![],
+            place_data,
+        });
+    }
+
+    let Ok(images_count) = database.get_multiple_places_images_count(&resolved_ids).await else {
         return HttpResponse::NotFound().json(ResponseError::new("places not found"));
     };
 
     let Ok(images) = database
-        .get_multiple_places_images(&places_ids, offset as i64, limit as i64)
+        .get_multiple_places_images(&resolved_ids, offset as i64, limit as i64)
         .await
     else {
         return HttpResponse::NotFound().json(ResponseError::new("places not found"));

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -617,3 +617,141 @@ async fn test_get_place_images_eth_caches_resolution() {
     assert!(response2.status().is_success());
     // wiremock .expect(1) will panic on drop if more than 1 request was made
 }
+
+#[actix_web::test]
+async fn test_post_multiple_places_images_with_eth_world_name() {
+    let mock_server = MockServer::start().await;
+
+    let world_place_id_1 = Uuid::new_v4().to_string();
+    let world_place_id_2 = Uuid::new_v4().to_string();
+    let regular_place_id = Uuid::new_v4().to_string();
+
+    Mock::given(method("GET"))
+        .and(path("/api/places"))
+        .and(query_param("names", "multi-world.eth"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(places_response(
+            2,
+            vec![world_place_id_1.as_str(), world_place_id_2.as_str()],
+        )))
+        .mount(&mock_server)
+        .await;
+
+    let (server, _) = create_test_server_with_places_url(&mock_server.uri()).await;
+    let address = server.addr();
+
+    // Upload 2 images to world scene 1
+    for i in 0..2 {
+        upload_public_test_image(
+            &format!("mw-p1-{i}.png"),
+            &address.to_string(),
+            &world_place_id_1,
+        )
+        .await;
+    }
+
+    // Upload 3 images to world scene 2
+    for i in 0..3 {
+        upload_public_test_image(
+            &format!("mw-p2-{i}.png"),
+            &address.to_string(),
+            &world_place_id_2,
+        )
+        .await;
+    }
+
+    // Upload 1 image to regular place
+    upload_public_test_image("mw-rp-0.png", &address.to_string(), &regular_place_id).await;
+
+    let request_body = serde_json::json!({
+        "placesIds": [regular_place_id, "multi-world.eth"]
+    });
+
+    let response = reqwest::Client::new()
+        .post(&format!(
+            "http://{}/api/places/images?offset=0&limit=20",
+            address
+        ))
+        .json(&request_body)
+        .send()
+        .await
+        .unwrap()
+        .json::<GetMultiplePlacesImagesResponse>()
+        .await
+        .unwrap();
+
+    assert_eq!(response.place_data.max_images, 6);
+    assert_eq!(response.images.len(), 6);
+}
+
+#[actix_web::test]
+async fn test_post_multiple_places_images_eth_empty_world() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/places"))
+        .and(query_param("names", "empty-multi.eth"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(places_response(0, vec![])),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let (server, _) = create_test_server_with_places_url(&mock_server.uri()).await;
+    let address = server.addr();
+
+    let request_body = serde_json::json!({
+        "placesIds": ["empty-multi.eth"]
+    });
+
+    let response = reqwest::Client::new()
+        .post(&format!(
+            "http://{}/api/places/images?offset=0&limit=20",
+            address
+        ))
+        .json(&request_body)
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+
+    let body = response
+        .json::<GetMultiplePlacesImagesResponse>()
+        .await
+        .unwrap();
+    assert_eq!(body.images.len(), 0);
+    assert_eq!(body.place_data.max_images, 0);
+}
+
+#[actix_web::test]
+async fn test_post_multiple_places_images_eth_api_error() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/places"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&mock_server)
+        .await;
+
+    let (server, _) = create_test_server_with_places_url(&mock_server.uri()).await;
+    let address = server.addr();
+
+    let request_body = serde_json::json!({
+        "placesIds": ["error-multi.eth"]
+    });
+
+    let response = reqwest::Client::new()
+        .post(&format!(
+            "http://{}/api/places/images?offset=0&limit=20",
+            address
+        ))
+        .json(&request_body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 502);
+
+    let body = response.json::<ResponseError>().await.unwrap();
+    assert!(body.get_message().contains("failed to resolve world name"));
+}


### PR DESCRIPTION
This commit updates the `get_multiple_places_images` function to resolve world place IDs when provided in the request. It adds error handling for failed resolutions, returning a 502 status code when necessary. Additionally, new tests are introduced to validate the functionality with various scenarios, including successful image retrieval and handling of empty or erroneous world names.