### PR TITLE
fix: enforce ownership on image metadata and bound request inputs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,28 @@
-# Copy this file to `.env` and fill in the values. `.env` is gitignored — never commit real tokens.
+# Copy this file to `.env` and adjust as needed. `.env` is gitignored — never commit real secrets.
+# Every value below is also a CLI flag (see `cargo run -- --help`); these are the defaults.
 
-# LocalStack Pro auth token, consumed by the `localstack` service in docker-compose.yml.
-# Required because the `localstack/localstack:latest` image is license-gated.
-# Get yours at https://app.localstack.cloud (Auth Tokens).
-LOCALSTACK_AUTH_TOKEN=
+# HTTP server
+PORT=3000
+API_URL=http://localhost:3000
+
+# PostgreSQL
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/camera_reel
+
+# S3 (local dev points at the moto mock on :4566; use real AWS values in production)
+AWS_REGION=us-east-1
+S3_URL=http://localhost:4566
+S3_BUCKET_NAME=camera-reel
+S3_ACCESS_KEY_ID=test
+S3_SECRET_ACCESS_KEY=test
+
+# SNS events (set the endpoint to the moto mock for local dev; leave unset for real AWS)
+AWS_SNS_ARN=arn:aws:sns:us-east-1:000000000000:events
+AWS_SNS_ENDPOINT=http://localhost:4566
+
+# Per-user image limit
+MAX_IMAGES_PER_USER=500
+
+# Places API
+PLACES_API_URL=https://places.decentraland.org
+PLACES_CACHE_TTL_SECONDS=300
+PLACES_CACHE_MAX_SIZE=1000

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to `.env` and fill in the values. `.env` is gitignored — never commit real tokens.
+
+# LocalStack Pro auth token, consumed by the `localstack` service in docker-compose.yml.
+# Required because the `localstack/localstack:latest` image is license-gated.
+# Get yours at https://app.localstack.cloud (Auth Tokens).
+LOCALSTACK_AUTH_TOKEN=

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,10 +36,14 @@ jobs:
       - name: Start LocalStack
         uses: LocalStack/setup-localstack@v0.2.2
         with:
-          image-tag: "latest"
+          # Community (free) pin. The 4.x `latest` image requires a valid Pro license;
+          # sns/s3/sqs are all free Community services, so no license is needed.
+          image-tag: "3.8"
           install-awslocal: "true"
           configuration: DEBUG=1,SERVICES=sns,s3,sqs
         env:
+          # Only used if you switch back to a Pro image with an active license;
+          # ignored by the Community image above.
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 
       - name: Setup AWS resources in LocalStack

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,26 +33,21 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Start LocalStack
-        uses: LocalStack/setup-localstack@v0.2.2
-        with:
-          # Community (free) pin. The 4.x `latest` image requires a valid Pro license;
-          # sns/s3/sqs are all free Community services, so no license is needed.
-          image-tag: "3.8"
-          install-awslocal: "true"
-          configuration: DEBUG=1,SERVICES=sns,s3,sqs
-        env:
-          # Only used if you switch back to a Pro image with an active license;
-          # ignored by the Community image above.
-          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+      - name: Start moto (AWS mock)
+        run: |
+          docker run -d --name moto -p 4566:5000 motoserver/moto:5.2.2
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:4566/moto-api/ >/dev/null && { echo "moto is ready"; break; }
+            sleep 1
+          done
 
-      - name: Setup AWS resources in LocalStack
+      - name: Setup AWS resources in moto
         run: |
           # Create SNS topic
-          awslocal sns create-topic --name events --region us-west-2
+          aws --endpoint-url=http://localhost:4566 sns create-topic --name events --region us-west-2
           # Create S3 bucket
-          awslocal s3 mb s3://camera-reel
-          awslocal s3api put-bucket-acl --bucket camera-reel --acl public-read
+          aws --endpoint-url=http://localhost:4566 s3 mb s3://camera-reel
+          aws --endpoint-url=http://localhost:4566 s3api put-bucket-acl --bucket camera-reel --acl public-read
 
       - name: Run tests
         run: cargo test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /target
 
-# Local environment files — may contain secrets (e.g. LOCALSTACK_AUTH_TOKEN)
+# Local environment files (may contain secrets)
 .env
 .env.*
 !.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /target
+
+# Local environment files — may contain secrets (e.g. LOCALSTACK_AUTH_TOKEN)
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ See `.env.example` for available configuration options.
 
 In order to successfully run this server, external dependencies such as databases and storage must be provided.
 
-To do so, this repository provides you with a `docker-compose.dev.yml` file for that purpose. In order to get the environment set up, run:
+To do so, this repository provides you with a `docker-compose.yml` file for that purpose. In order to get the environment set up, run:
 
 ```bash
-docker-compose -f docker-compose.dev.yml up -d
+docker compose up -d
 ```
 
 Or using just (if installed):
@@ -154,8 +154,8 @@ just run-services
 
 This will start:
 
-- PostgreSQL database on port `5432`
-- MinIO (local S3) on port `9000` (API) and `9001` (Console)
+- PostgreSQL on port `5432`
+- [moto](https://github.com/getmoto/moto) (an Apache-2.0 AWS mock for S3/SNS/SQS) on port `4566`, pre-seeded with the `events` SNS topic and `camera-reel` S3 bucket
 
 #### Running in development mode
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
-version: "3.8"
-
 services:
   localstack:
-    image: localstack/localstack:latest
+    # Pinned to a Community (free) 3.x image. This service only needs sns/s3/sqs, which
+    # are all Community features. The `latest` (4.x) image hard-requires a valid Pro
+    # license. Switch to a newer tag / `latest` only if you have an active Pro license.
+    image: localstack/localstack:3.8
     ports:
       - "4566:4566"
     environment:
+      # Only consumed by Pro images; ignored by the Community image above.
       # Provided via the host environment or a local .env file (never commit the value).
       - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}
       - SERVICES=sns,s3,sqs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     ports:
       - "4566:4566"
     environment:
+      # Provided via the host environment or a local .env file (never commit the value).
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}
       - SERVICES=sns,s3,sqs
       - DEBUG=1
       - DOCKER_HOST=unix:///var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,38 @@
 services:
-  localstack:
-    # Pinned to a Community (free) 3.x image. This service only needs sns/s3/sqs, which
-    # are all Community features. The `latest` (4.x) image hard-requires a valid Pro
-    # license. Switch to a newer tag / `latest` only if you have an active Pro license.
-    image: localstack/localstack:3.8
+  # AWS mock (S3 + SNS + SQS). moto is Apache-2.0 licensed and replaces LocalStack,
+  # which now requires a (paid) Pro license. Exposed on host port 4566 — moto listens
+  # on 5000 in-container — to match the service's default S3/SNS endpoints, so no app
+  # or test configuration changes are needed.
+  moto:
+    image: motoserver/moto:5.2.2
     ports:
-      - "4566:4566"
-    environment:
-      # Only consumed by Pro images; ignored by the Community image above.
-      # Provided via the host environment or a local .env file (never commit the value).
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}
-      - SERVICES=sns,s3,sqs
-      - DEBUG=1
-      - DOCKER_HOST=unix:///var/run/docker.sock
-      - AWS_DEFAULT_REGION=us-west-2
-      - AWS_ACCESS_KEY_ID=test
-      - AWS_SECRET_ACCESS_KEY=test
-    volumes:
-      - ./localstack:/etc/localstack/init/ready.d
-      - /var/run/docker.sock:/var/run/docker.sock
+      - "4566:5000"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4566/health"]
-      interval: 10s
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/moto-api/')"]
+      interval: 5s
       timeout: 5s
       retries: 10
-      start_period: 10s
+      start_period: 5s
+
+  # One-shot job that creates the SNS topic and S3 bucket the service expects.
+  # moto holds state in memory, so these are recreated whenever the stack starts.
+  aws-init:
+    image: amazon/aws-cli:latest
+    depends_on:
+      moto:
+        condition: service_healthy
+    environment:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_DEFAULT_REGION: us-west-2
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        aws --endpoint-url=http://moto:5000 sns create-topic --name events || true
+        aws --endpoint-url=http://moto:5000 s3 mb s3://camera-reel || true
+        aws --endpoint-url=http://moto:5000 s3api put-bucket-acl --bucket camera-reel --acl public-read || true
+        echo "moto AWS resources created"
 
   postgres:
     container_name: "camera_reel_db"

--- a/justfile
+++ b/justfile
@@ -1,3 +1,3 @@
 run-services:
-  docker-compose -f docker-compose.yml up -d
+  docker compose up -d
 

--- a/justfile
+++ b/justfile
@@ -1,3 +1,3 @@
 run-services:
-  docker-compose -f docker-compose.dev.yml up -d
+  docker-compose -f docker-compose.yml up -d
 

--- a/localstack/01-create-sns.sh
+++ b/localstack/01-create-sns.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-awslocal sns create-topic --name events --region us-west-2

--- a/localstack/02-create-s3.sh
+++ b/localstack/02-create-s3.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-echo "Creating S3 bucket: camera-reel"
-awslocal s3 mb s3://camera-reel
-
-echo "Configuring S3 bucket public access..."
-awslocal s3api put-bucket-acl --bucket camera-reel --acl public-read

--- a/src/api/get.rs
+++ b/src/api/get.rs
@@ -14,6 +14,15 @@ use crate::{
     Settings,
 };
 
+/// Maximum number of place IDs accepted in a single `POST /places/images` request.
+/// Bounds the fan-out work (per-id world-name resolution + DB query size) so a single
+/// request can't exhaust server resources.
+const MAX_PLACES_IDS: usize = 100;
+
+/// Upper bound for the client-supplied pagination `limit`. Values above this are clamped
+/// so a request can't drive an oversized DB query / response.
+const MAX_LIMIT: u64 = 100;
+
 #[tracing::instrument(skip(settings))]
 #[utoipa::path(
     tag = "images",
@@ -30,29 +39,51 @@ async fn get_image(settings: Data<Settings>, image_id: Path<String>) -> impl Res
 #[tracing::instrument(skip(database))]
 #[utoipa::path(
     tag = "images",
-    context_path = "/api", 
+    context_path = "/api",
     responses(
         (status = 200, description = "Get image metadata", body = Image),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
         (status = 404, description = "Not found")
     )
 )]
 #[get("/images/{image_id}/metadata")]
-async fn get_metadata(database: Data<Database>, image_id: Path<String>) -> impl Responder {
+async fn get_metadata(
+    database: Data<Database>,
+    image_id: Path<String>,
+    request: HttpRequest,
+) -> impl Responder {
     let image_id = image_id.into_inner();
-    match database.get_image(&image_id).await {
-        Ok(image) => {
-            let image: Image = image.into();
-            HttpResponse::Ok().json(image)
-        }
+    let image = match database.get_image(&image_id).await {
+        Ok(image) => image,
         Err(sqlx::Error::ColumnDecode { source, .. }) => {
             tracing::debug!("Couldn't decode image metadata: {source:?}");
-            HttpResponse::InternalServerError().json(ResponseError::new("couldn't decode image"))
+            return HttpResponse::InternalServerError()
+                .json(ResponseError::new("couldn't decode image"));
         }
         Err(e) => {
             tracing::debug!("Image not found: {e:?}");
-            HttpResponse::NotFound().json(ResponseError::new("image not found"))
+            return HttpResponse::NotFound().json(ResponseError::new("image not found"));
+        }
+    };
+
+    // Private images expose sensitive metadata (visible people, scene location, realm,
+    // owner address), so they must only be served to their owner. Public images stay open.
+    if !image.is_public {
+        match AuthUser::extract(&request).await {
+            Ok(AuthUser { address }) => {
+                if !image.user_address.eq_ignore_ascii_case(&address) {
+                    return HttpResponse::Forbidden().json(ResponseError::new("forbidden"));
+                }
+            }
+            Err(_) => {
+                return HttpResponse::Unauthorized().json(ResponseError::new("unauthorized"));
+            }
         }
     }
+
+    let image: Image = image.into();
+    HttpResponse::Ok().json(image)
 }
 
 #[derive(Deserialize, Debug, IntoParams)]
@@ -178,6 +209,7 @@ async fn get_user_images(
         limit,
         compact,
     } = query_params.into_inner();
+    let limit = limit.min(MAX_LIMIT);
 
     let Ok(images_count) = database
         .get_user_images_count(&user_address, only_public_images)
@@ -260,6 +292,7 @@ async fn get_place_images(
 ) -> impl Responder {
     let place_id = place_id.into_inner();
     let GetPlaceImagesQuery { offset, limit } = query_params.into_inner();
+    let limit = limit.min(MAX_LIMIT);
 
     if place_id.ends_with(".eth") {
         let place_ids = match places_client.get_world_place_ids(&place_id).await {
@@ -369,10 +402,17 @@ async fn get_multiple_places_images(
     places_client: Data<PlacesClient>,
 ) -> impl Responder {
     let GetMultiplePlacesImagesQuery { offset, limit } = query_params.into_inner();
+    let limit = limit.min(MAX_LIMIT);
     let GetMultiplePlacesImagesBody { places_ids } = request.into_inner();
 
     if places_ids.is_empty() {
         return HttpResponse::BadRequest().json(ResponseError::new("no place IDs provided"));
+    }
+
+    if places_ids.len() > MAX_PLACES_IDS {
+        return HttpResponse::BadRequest().json(ResponseError::new(&format!(
+            "too many place IDs provided, maximum is {MAX_PLACES_IDS}"
+        )));
     }
 
     let mut resolved_ids: Vec<String> = Vec::new();

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -200,8 +200,17 @@ async fn test_delete_image() {
     let place_id = Uuid::new_v4().to_string();
 
     let id = upload_test_image("image.png", &address.to_string(), &place_id).await;
+
+    // The image is private, so its owner must authenticate to read the metadata.
+    let metadata_path = format!("/api/images/{id}/metadata");
+    let metadata_headers = get_signed_headers(create_test_identity(), "get", &metadata_path, "");
     let response = reqwest::Client::new()
-        .get(&format!("http://{}/api/images/{}/metadata", address, id))
+        .get(&format!("http://{}{}", address, metadata_path))
+        .header(metadata_headers[0].0.clone(), metadata_headers[0].1.clone())
+        .header(metadata_headers[1].0.clone(), metadata_headers[1].1.clone())
+        .header(metadata_headers[2].0.clone(), metadata_headers[2].1.clone())
+        .header(metadata_headers[3].0.clone(), metadata_headers[3].1.clone())
+        .header(metadata_headers[4].0.clone(), metadata_headers[4].1.clone())
         .send()
         .await
         .unwrap();
@@ -273,9 +282,17 @@ async fn test_update_image_visibility() {
         .unwrap();
     assert!(response.status().is_success());
 
-    // Check if visibility was updated
+    // Check if visibility was updated. The image is now private, so the owner must
+    // authenticate to read its metadata.
+    let metadata_path = format!("/api/images/{id}/metadata");
+    let metadata_headers = get_signed_headers(create_test_identity(), "get", &metadata_path, "");
     let response = reqwest::Client::new()
-        .get(&format!("http://{}/api/images/{}/metadata", address, id))
+        .get(&format!("http://{}{}", address, metadata_path))
+        .header(metadata_headers[0].0.clone(), metadata_headers[0].1.clone())
+        .header(metadata_headers[1].0.clone(), metadata_headers[1].1.clone())
+        .header(metadata_headers[2].0.clone(), metadata_headers[2].1.clone())
+        .header(metadata_headers[3].0.clone(), metadata_headers[3].1.clone())
+        .header(metadata_headers[4].0.clone(), metadata_headers[4].1.clone())
         .send()
         .await
         .unwrap();
@@ -322,6 +339,92 @@ async fn test_update_image_visibility() {
         timestamp <= now && timestamp >= now - 60,
         "Timestamp should be recent"
     );
+}
+
+#[actix_web::test]
+async fn test_get_public_image_metadata_without_auth_succeeds() {
+    let (server, _) = create_test_server().await;
+    let address = server.addr();
+    let place_id = get_place_id();
+
+    let id = upload_public_test_image("public-meta.png", &address.to_string(), &place_id).await;
+
+    // Public images expose their metadata to anyone, no auth required.
+    let response = reqwest::Client::new()
+        .get(&format!("http://{}/api/images/{}/metadata", address, id))
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+    let image = response.json::<Image>().await.unwrap();
+    assert_eq!(image.is_public, true);
+}
+
+#[actix_web::test]
+async fn test_get_private_image_metadata_without_auth_is_unauthorized() {
+    let (server, _) = create_test_server().await;
+    let address = server.addr();
+    let place_id = get_place_id();
+
+    let id = upload_test_image("private-noauth.png", &address.to_string(), &place_id).await;
+
+    // Private image metadata must not be served to unauthenticated callers.
+    let response = reqwest::Client::new()
+        .get(&format!("http://{}/api/images/{}/metadata", address, id))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 401);
+}
+
+#[actix_web::test]
+async fn test_get_private_image_metadata_as_owner_succeeds() {
+    let (server, _) = create_test_server().await;
+    let address = server.addr();
+    let place_id = get_place_id();
+
+    let id = upload_test_image("private-owner.png", &address.to_string(), &place_id).await;
+
+    // The owner can read their own private image metadata when authenticated.
+    let path = format!("/api/images/{id}/metadata");
+    let headers = get_signed_headers(create_test_identity(), "get", &path, "");
+    let response = reqwest::Client::new()
+        .get(&format!("http://{}{}", address, path))
+        .header(headers[0].0.clone(), headers[0].1.clone())
+        .header(headers[1].0.clone(), headers[1].1.clone())
+        .header(headers[2].0.clone(), headers[2].1.clone())
+        .header(headers[3].0.clone(), headers[3].1.clone())
+        .header(headers[4].0.clone(), headers[4].1.clone())
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+    let image = response.json::<Image>().await.unwrap();
+    assert_eq!(image.is_public, false);
+}
+
+#[actix_web::test]
+async fn test_post_multiple_places_images_too_many_ids() {
+    let (server, _) = create_test_server().await;
+    let address = server.addr();
+
+    // 101 IDs exceeds the cap and must be rejected before any DB work.
+    let places_ids: Vec<String> = (0..101).map(|_| Uuid::new_v4().to_string()).collect();
+    let request_body = serde_json::json!({ "placesIds": places_ids });
+
+    let response = reqwest::Client::new()
+        .post(&format!("http://{}/api/places/images", address))
+        .json(&request_body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 400);
+    let body = response.json::<ResponseError>().await.unwrap();
+    assert!(body.get_message().contains("too many place IDs"));
 }
 
 #[actix_web::test]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -14,8 +14,8 @@ use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::common::{
-    create_test_identity, create_test_server, create_test_server_with_places_url,
-    get_signed_headers, poll_sqs_for_message_with_filter,
+    create_other_identity, create_test_identity, create_test_server,
+    create_test_server_with_places_url, get_signed_headers, poll_sqs_for_message_with_filter,
 };
 
 mod common;
@@ -404,6 +404,31 @@ async fn test_get_private_image_metadata_as_owner_succeeds() {
     assert!(response.status().is_success());
     let image = response.json::<Image>().await.unwrap();
     assert_eq!(image.is_public, false);
+}
+
+#[actix_web::test]
+async fn test_get_private_image_metadata_as_non_owner_is_forbidden() {
+    let (server, _) = create_test_server().await;
+    let address = server.addr();
+    let place_id = get_place_id();
+
+    let id = upload_test_image("private-other.png", &address.to_string(), &place_id).await;
+
+    // A different authenticated user must not read someone else's private metadata.
+    let path = format!("/api/images/{id}/metadata");
+    let headers = get_signed_headers(create_other_identity(), "get", &path, "");
+    let response = reqwest::Client::new()
+        .get(&format!("http://{}{}", address, path))
+        .header(headers[0].0.clone(), headers[0].1.clone())
+        .header(headers[1].0.clone(), headers[1].1.clone())
+        .header(headers[2].0.clone(), headers[2].1.clone())
+        .header(headers[3].0.clone(), headers[3].1.clone())
+        .header(headers[4].0.clone(), headers[4].1.clone())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 403);
 }
 
 #[actix_web::test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,7 +16,7 @@ use camera_reel_service::{
     sns::SNSPublisher,
     Environment, Settings,
 };
-use dcl_crypto::Identity;
+use dcl_crypto::{Account, Expiration, Identity};
 use rand::{distributions::Alphanumeric, Rng};
 use s3::{
     bucket_ops::CreateBucketResponse, creds::Credentials, Bucket, BucketConfiguration,
@@ -48,6 +48,16 @@ pub fn create_test_identity() -> dcl_crypto::Identity {
      ]
     }"#,
   ).unwrap()
+}
+
+/// Creates a valid signed identity for a *different* (random) signer than
+/// `create_test_identity`. Used to exercise authenticated-but-not-owner paths.
+pub fn create_other_identity() -> dcl_crypto::Identity {
+    let signer = Account::random();
+    Identity::from_signer(
+        &signer,
+        Expiration::try_from("3021-10-16T22:32:29.626Z").unwrap(),
+    )
 }
 
 fn create_string() -> String {


### PR DESCRIPTION
## Summary

Fixes two reported security issues plus a related DoS vector found while investigating them. All changes are in `src/api/get.rs`.

Closes #54
Closes #55

### #54 — IDOR: image metadata served without `is_public`/ownership check
`GET /api/images/{id}/metadata` returned the full `Image` (visible people, scene location, realm, owner address) with no auth or ownership check. Now:

- **Public** image → served to anyone (unchanged).
- **Private** image + no/invalid auth → `401 Unauthorized`.
- **Private** image + authenticated but not the owner → `403 Forbidden`.
- **Private** image + owner → served.

Uses the optional `AuthUser::extract(&request)` pattern (like `get_user_images`) so public images stay open, and `eq_ignore_ascii_case` for address matching — consistent with `delete.rs` / `update.rs`. OpenAPI responses updated with 401/403.

### #55 — DoS: unbounded `places_ids` in `POST /api/places/images`
Added `MAX_PLACES_IDS = 100`. Oversized arrays are rejected with `400` **before** any world-name resolution or DB query.

### Additional — unbounded pagination `limit` (same DoS class)
`limit: u64` was passed straight into SQL `LIMIT` in `get_user_images`, `get_place_images`, and `get_multiple_places_images`, so `?limit=100000000` drove an oversized query/response (and `u64`→`i64` wraparound for huge values). Added `MAX_LIMIT = 100` and clamp at the point of use. Clamping (not rejecting) keeps existing clients working — standard pagination behavior.

## Tests
- Added: public-metadata-without-auth (200), private-metadata-without-auth (401), private-metadata-as-owner (200), too-many-place-ids (400).
- Updated `test_delete_image` and `test_update_image_visibility`, which previously relied on unauthenticated access to private metadata — now authenticate as the owner.

## Verification
- `cargo check --tests` and `cargo clippy --tests` clean (no new warnings).
- Full `tests/api.rs` integration suite: **22 passed, 0 failed** (run against Postgres + LocalStack).

## Out of scope (flagging for follow-up)
- `GET /api/images/{image_id}` redirects to the raw image binary in a public S3/CDN bucket regardless of `is_public`, so a private image's *bytes* aren't protected at this layer. Enforcing this would need signed URLs or proxying — a larger change worth a separate ticket.
- A `.eth` entry in `places_ids` still fan-expands to many resolved place IDs; the input cap (100) bounds upstream calls and the `limit` clamp bounds the response, so it's reasonably contained.