### PR TITLE
build: harden and slim the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Build artifacts (multi-GB) — never send to the Docker daemon
+target/
+
+# VCS / CI
+.git/
+.gitignore
+.github/
+
+# Local dev tooling, compose, and docs (not needed to build the binary)
+docker-compose*.yml
+run-docker.sh
+Dockerfile
+.dockerignore
+.env
+.env.*
+!.env.example
+docs/
+*.md
+.claude/
+data-*.csv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       AWS_DEFAULT_REGION: us-west-2
     services:
       postgres:
-        image: postgres
+        image: postgres:latest@sha256:29ee7bb30d804447dc9a91fd0d74322ae1dc3a4072cc6346f70a5ed6e783b565
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: camera_reel
@@ -35,7 +35,7 @@ jobs:
 
       - name: Start moto (AWS mock)
         run: |
-          docker run -d --name moto -p 4566:5000 motoserver/moto:5.2.2
+          docker run -d --name moto -p 4566:5000 motoserver/moto:5.2.2@sha256:d8ae5edc2bf080e7e4c13f9bd4b29b53ac3b4427e92956318db3dbe23ec43eb7
           for i in $(seq 1 30); do
             curl -sf http://localhost:4566/moto-api/ >/dev/null && { echo "moto is ready"; break; }
             sleep 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,6 @@ wiremock = "0.5"
 
 [[example]]
 name = "upload-image"
+
+[profile.release]
+strip = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ COPY . .
 RUN cargo build --release
 
 FROM debian:13-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e AS runtime
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     libssl3t64 \
     && rm -rf /var/lib/apt/lists/*
 
 # Run as an unprivileged user
-RUN useradd --system --no-create-home --uid 10001 appuser
+RUN useradd --system --no-create-home --no-log-init --uid 10001 appuser
 
 COPY --from=builder /app/target/release/camera-reel-service /usr/local/bin/camera-reel-service
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86 AS chef
+FROM rust:1.86@sha256:300ec56abce8cc9448ddea2172747d048ed902a3090e6b57babb2bf19f754081 AS chef
 RUN cargo install --version 0.1.62 cargo-chef --locked
 
 WORKDIR /app
@@ -15,7 +15,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release
 
-FROM debian:13-slim AS runtime
+FROM debian:13-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e AS runtime
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl3t64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,7 @@ FROM chef AS planner
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM chef AS builder 
-ARG PROJECT
-RUN apt update && apt-get install -y protobuf-compiler
+FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 
 # Build dependencies - this is the caching Docker layer!
@@ -17,13 +15,18 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release
 
-FROM debian:12-slim AS runtime
+FROM debian:13-slim AS runtime
 RUN apt-get update && apt-get install -y \
     ca-certificates \
-    libssl3 \
+    libssl3t64 \
     && rm -rf /var/lib/apt/lists/*
 
-ARG PROJECT
+# Run as an unprivileged user
+RUN useradd --system --no-create-home --uid 10001 appuser
+
 COPY --from=builder /app/target/release/camera-reel-service /usr/local/bin/camera-reel-service
+
+USER appuser
+EXPOSE 3000
 
 ENTRYPOINT [ "/usr/local/bin/camera-reel-service" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # on 5000 in-container — to match the service's default S3/SNS endpoints, so no app
   # or test configuration changes are needed.
   moto:
-    image: motoserver/moto:5.2.2
+    image: motoserver/moto:5.2.2@sha256:d8ae5edc2bf080e7e4c13f9bd4b29b53ac3b4427e92956318db3dbe23ec43eb7
     ports:
       - "4566:5000"
     healthcheck:
@@ -17,7 +17,7 @@ services:
   # One-shot job that creates the SNS topic and S3 bucket the service expects.
   # moto holds state in memory, so these are recreated whenever the stack starts.
   aws-init:
-    image: amazon/aws-cli:latest
+    image: amazon/aws-cli:latest@sha256:017ee8e2aa180f47597daa31219991fbea9377645e55f8070aeaadb156573807
     depends_on:
       moto:
         condition: service_healthy
@@ -36,7 +36,7 @@ services:
 
   postgres:
     container_name: "camera_reel_db"
-    image: "postgres:latest"
+    image: "postgres:latest@sha256:29ee7bb30d804447dc9a91fd0d74322ae1dc3a4072cc6346f70a5ed6e783b565"
     restart: always
     user: postgres
     volumes:


### PR DESCRIPTION
## Summary

Reviewed and improved the Docker image. All changes verified with a clean `docker build` and a smoke test of the resulting image.

### Changes
- **Add `.dockerignore`** (biggest win): without it, every `docker build` sent the entire build context — including a multi-GB `target/` — to the daemon, and copied the host's `target/` into the builder, undermining cargo-chef's dependency-layer caching.
- **Drop `protobuf-compiler`**: there's no `prost`/`tonic` in the dependency tree; the only protobuf is the pure-Rust `protobuf` crate (pulled in by the Prometheus metrics dep), which needs no `protoc`. Confirmed the image builds without it.
- **Run as non-root**: the runtime stage now creates and switches to `appuser` (uid 10001) instead of running as root.
- **Bump runtime base `debian:12-slim` → `debian:13-slim`** (and `libssl3` → `libssl3t64`, the trixie package after the 64-bit `time_t` transition). Confirmed the binary resolves `libssl.so.3` and runs on Debian 13.
- **Remove the unused `ARG PROJECT`**, switch `apt` → `apt-get`, add `EXPOSE 3000`.
- **`strip = true`** under `[profile.release]` to shrink the binary/image.

### Verification
- Clean `docker build` succeeds (deps compiled from scratch; no `protoc`).
- `docker run --entrypoint id …` → `uid=10001(appuser)`.
- `docker run … --help` exits 0 (binary loads its shared libs).
- `ldd` shows `libssl.so.3` / `libcrypto.so.3` resolved on the Debian 13 runtime.
- Resulting image: ~142 MB.

### Not included (flagged for later)
- Switching from OpenSSL/native-tls to `rustls` would allow a `distroless`/static runtime (smaller, lower CVE surface), but that's a larger change best done separately.